### PR TITLE
Use lodash core package to resolve security vulnerability and follow recommended flow. 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 const puppeteer = require('puppeteer');
-const { has, pick, omit} = require("lodash");
+const omit = require('lodash/omit');
+const pick = require('lodash/pick');
+const has = require('lodash/has');
 const isUrl = require('is-url');
 const fs = require('fs').promises;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,5 @@
 const puppeteer = require('puppeteer');
-const omit = require('lodash.omit');
-const pick = require('lodash.pick');
-const has = require('lodash.has');
+const { has, pick, omit} = require("lodash");
 const isUrl = require('is-url');
 const fs = require('fs').promises;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "is-url": "^1.2.4",
-        "lodash.has": "^4.5.2",
-        "lodash.omit": "^4.5.0",
-        "lodash.pick": "^4.4.0",
+        "lodash": "^4.17.21",
         "puppeteer": "^22.6.2"
       },
       "devDependencies": {
@@ -3780,17 +3778,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash.has": {
-      "version": "4.5.2",
-      "license": "MIT"
-    },
-    "node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.pick": {
-      "version": "4.4.0",
-      "license": "MIT"
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppeteer-html-pdf",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "HTML to PDF converter for Node.js",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
   "homepage": "https://github.com/ultimateakash/puppeteer-html-pdf#readme",
   "dependencies": {
     "is-url": "^1.2.4",
-    "lodash.has": "^4.5.2",
-    "lodash.omit": "^4.5.0",
-    "lodash.pick": "^4.4.0",
+    "lodash": "^4.17.21",
     "puppeteer": "^22.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
There is a [High severity vulnerability in lodash.pick package](https://github.com/advisories/GHSA-p6mc-m468-83gw), this no longer being maintained and the [Per Method Packages method is no longer recommended by the lodash team](https://lodash.com/per-method-packages).

This MR changes the dependancy to the main lodash package and imports the methods using the direct require method.